### PR TITLE
fix: resolve missing props for drawer and also invalid redirection

### DIFF
--- a/src/components/JobFilters.jsx
+++ b/src/components/JobFilters.jsx
@@ -50,14 +50,15 @@ const JobFilters = ({ appliedFilters }) => {
           },
           marginBottom: "10px",
         }}
-        onClick={() => setDrawerOpen(open)}
+        onClick={() => setDrawerOpen(true)}
       >
         Toggle Filters
       </Button>
       <SwipeableDrawer
         anchor="bottom"
         open={isDrawerOpen}
-        onClose={() => setDrawerOpen(open)}
+        onOpen={() => setDrawerOpen(true)}
+        onClose={() => setDrawerOpen(false)}
       >
         <Grid
           container


### PR DESCRIPTION
Resolves #1 

Cause of issue : 
- Due to a missing prop in the swipable drawer, the flags passed were incorrect. That caused redirection in a new tab upon click of filter toggle button. Although that does not explain why a `button` click would act like an `a` tag with `_blank` target and modified `href`. 

Further exploring of MUI can be done, if required to understand how this happens.